### PR TITLE
Use DB_OPERATION_NAME instead of DB_OPERATIONNAME

### DIFF
--- a/src/Watchers/DatabaseQueryWatcher.php
+++ b/src/Watchers/DatabaseQueryWatcher.php
@@ -44,7 +44,7 @@ class DatabaseQueryWatcher implements WatcherInterface
             'db.sql.raw' => $rawSql,
             TraceAttributes::DB_SYSTEM => $query->connection->getDriverName(),
             TraceAttributes::DB_NAMESPACE => $query->connection->getDatabaseName(),
-            TraceAttributes::DB_OPERATIONNAME => $operationName,
+            TraceAttributes::DB_OPERATION_NAME => $operationName,
             TraceAttributes::DB_QUERYTEXT => $query->sql,
             TraceAttributes::DB_COLLECTIONANEM => $table,
         ]);


### PR DESCRIPTION
The constant `DB_OPERATIONNAME` does not exist, leading to an error when used. To resolve this issue, update all references to `DB_OPERATIONNAME` and replace them with the correct constant, `DB_OPERATION_NAME`.  
